### PR TITLE
#11 Fix for multiple line pasting into the REPL

### DIFF
--- a/Src/CShell/Modules/Repl/Controls/CSRepl.xaml.cs
+++ b/Src/CShell/Modules/Repl/Controls/CSRepl.xaml.cs
@@ -75,6 +75,7 @@ namespace CShell.Modules.Repl.Controls
             textEditor.FontFamily = new FontFamily("Consolas");
             var convertFrom = new FontSizeConverter().ConvertFrom("10pt");
             if (convertFrom != null) textEditor.FontSize = (double)convertFrom;
+            textEditor.PreviewKeyDown += TextEditorOnPreviewKeyDown;
             textEditor.TextArea.PreviewKeyDown += TextAreaOnPreviewKeyDown;
             textEditor.IsEnabled = false;
             textEditor.SyntaxHighlighting = HighlightingManager.Instance.GetDefinition("C#");
@@ -372,6 +373,19 @@ namespace CShell.Modules.Repl.Controls
             }
         }
 
+        private void TextEditorOnPreviewKeyDown(object sender, KeyEventArgs keyEventArgs)
+        {
+            //If pasting text, sanitize it for REPL input.
+            if ((Keyboard.IsKeyDown(Key.LeftCtrl) && Keyboard.IsKeyDown(Key.V)) ||
+                    (Keyboard.IsKeyDown(Key.RightCtrl) && Keyboard.IsKeyDown(Key.V)))
+            {
+                var currentClipboardText = Clipboard.GetText();
+                var newClipboardText = ToREPLSanitizedString(currentClipboardText);
+                Write(newClipboardText, TextType.Repl);
+                keyEventArgs.Handled = true;
+            }
+        }
+
         internal IDocument GetCompletionDocument(out int offset)
         {
             var lineText = GetCurrentLineText();
@@ -546,6 +560,12 @@ namespace CShell.Modules.Repl.Controls
                 return sb.ToString();
             }
             return o.ToString();
+        }
+
+        private string ToREPLSanitizedString(string text)
+        {
+            text = text.Replace(Environment.NewLine, string.Empty);
+            return text;
         }
         #endregion
 


### PR DESCRIPTION
A potential solution for https://github.com/lukebuehler/CShell/issues/11.

This change subscribes the `textEditor` to an event, `TextEditorOnPreviewKeyDown`, that recognizes a paste action and sanitizes the input in the clipboard.

The data in the clipboard remains exactly how the user copied it. The sanitized data is simply spit out into the editor.

This:
![replcopytextsource](https://cloud.githubusercontent.com/assets/1616060/3127432/7166606e-e7be-11e3-8966-424121decfa6.PNG)

Would paste as:
![replpasteexample](https://cloud.githubusercontent.com/assets/1616060/3127441/c14422ec-e7be-11e3-8e03-3967f724fb73.PNG)
