### PR TITLE
Blank line at the end of the command history in REPL

### DIFF
--- a/Src/CShell/Modules/Repl/Controls/CommandHistory.cs
+++ b/Src/CShell/Modules/Repl/Controls/CommandHistory.cs
@@ -54,7 +54,7 @@ namespace CShell.Modules.Repl.Controls
 
         internal bool DoesNextCommandExist()
         {
-            return currentPosn < commandHistory.Count - 1;
+            return currentPosn < commandHistory.Count;
         }
 
         internal string GetPreviousCommand()
@@ -65,8 +65,16 @@ namespace CShell.Modules.Repl.Controls
 
         internal string GetNextCommand()
         {
-            lastCommand = (string)commandHistory[++currentPosn];
-            return LastCommand;
+            if (currentPosn == commandHistory.Count - 1)
+            {
+                currentPosn++;
+                return "";
+            }
+            else
+            { 
+                lastCommand = (string)commandHistory[++currentPosn];
+                return LastCommand;
+            }
         }
 
         internal string LastCommand


### PR DESCRIPTION
I guess this one is up to personal taste. I sometimes go back in command history to check something and then back down again to write a new command. In the current implementation it stops at the last command forcing me to delete all the text in that line and then enter my new command. My proposed change gives you a blank line when going past the last command in command history.

A problem with my implementation is that if you write something on a blank line, go up in command history and then back down again, you get a blank line - and the stuff you wrote is gone. However, I wasn't sure were to store that text without passing an argument to GetPreviousCommand(). Maybe I'll take a stab at that later.
