### PR TITLE
Missing dll

### DIFF
--- a/Src/CShell.sln
+++ b/Src/CShell.sln
@@ -129,6 +129,7 @@ Global
 		{380E341F-F818-4479-95D9-491318024966}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{380E341F-F818-4479-95D9-491318024966}.Release|x86.ActiveCfg = Release|Any CPU
 		{5B274665-BF8F-4212-AEE2-2EB4A14710AC}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{5B274665-BF8F-4212-AEE2-2EB4A14710AC}.Debug|Any CPU.Build.0 = Debug|x86
 		{5B274665-BF8F-4212-AEE2-2EB4A14710AC}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
 		{5B274665-BF8F-4212-AEE2-2EB4A14710AC}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{5B274665-BF8F-4212-AEE2-2EB4A14710AC}.Debug|x86.ActiveCfg = Debug|x86

--- a/Src/SetupProject/Product.wxs
+++ b/Src/SetupProject/Product.wxs
@@ -91,6 +91,10 @@
         <File Id="Caliburn.Micro.Platform.dll" Source="$(var.CShell.TargetDir)\Caliburn.Micro.Platform.dll">
         </File>
       </Component>
+      <Component Id="Common.Logging.dll" Guid="1B35863B-C88F-4498-A1B1-674BE766AB69">
+        <File Id="Common.Logging.dll" Source="$(var.CShell.TargetDir)\Common.Logging.dll">
+        </File>
+      </Component>
       <Component Id="CShell.Completion.dll" Guid="836e5704-c144-4c1b-a988-e23236281533">
         <File Id="CShell.Completion.dll" Source="$(var.CShell.TargetDir)\CShell.Completion.dll">
         </File>


### PR DESCRIPTION
#86 Looks like we were missing the logging dll.  Works great after adding it in.
